### PR TITLE
Prevent collision of GPU workloads and GPU Operator's validator

### DIFF
--- a/examples/aws-eks-existing-vpc/main.tf
+++ b/examples/aws-eks-existing-vpc/main.tf
@@ -102,8 +102,19 @@ module "addons_aws_ebs_csi_driver" {
 }
 
 module "addons_nvidia_gpu_operator" {
-  source           = "github.com/vessl-ai/vessl-cloud-integration//modules/kubernetes-addons/nvidia-gpu-operator?ref=0.1.1"
+  source           = "github.com/vessl-ai/vessl-cloud-integration//modules/kubernetes-addons/nvidia-gpu-operator?ref=0.1.4"
   eks_cluster_name = module.eks.cluster_name
+
+  helm_values_force_string = {
+    # Disable launching Pod 'nvidia-device-plugin-validator', which briefly occupies a GPU and
+    # thus has a race condition with pending GPU workloads when a node is created by cluster scale-up.
+    # cf.: NVIDIA/gpu-operator#140, NVIDIA/gpu-operator#475
+    #
+    # Plain "false" in helm_values will result in YAML false of type boolean which
+    # then triggers error in K8s API; force the value as string.
+    "validator.plugin.env[0].name"  = "WITH_WORKLOAD"
+    "validator.plugin.env[0].value" = "false"
+  }
 }
 
 module "addons_vessl_cluster_agent" {

--- a/modules/kubernetes-addons/nvidia-gpu-operator/main.tf
+++ b/modules/kubernetes-addons/nvidia-gpu-operator/main.tf
@@ -39,6 +39,15 @@ resource "helm_release" "nvidia_gpu_operator" {
     }
   }
 
+  dynamic "set" {
+    for_each = var.helm_values_force_string
+    content {
+      name  = set.key
+      value = set.value
+      type  = "string"
+    }
+  }
+
   depends_on = [
     kubernetes_namespace_v1.nvidia_gpu_operator
   ]

--- a/modules/kubernetes-addons/nvidia-gpu-operator/variables.tf
+++ b/modules/kubernetes-addons/nvidia-gpu-operator/variables.tf
@@ -1,7 +1,13 @@
 variable "helm_values" {
   type        = map(any)
   default     = {}
-  description = "Additional settings which will be passed to the Helm chart values.https://github.com/NVIDIA/gpu-operator/blob/master/deployments/gpu-operator/Chart.yaml"
+  description = "Additional settings which will be passed to the Helm chart values. https://github.com/NVIDIA/gpu-operator/blob/master/deployments/gpu-operator/Chart.yaml"
+}
+
+variable "helm_values_force_string" {
+  type        = map(any)
+  default     = {}
+  description = "Additional settings which will be passed to the Helm chart values. The values will be forced to string (see helm/helm#2848). https://github.com/NVIDIA/gpu-operator/blob/master/deployments/gpu-operator/Chart.yaml"
 }
 
 variable "eks_cluster_name" {


### PR DESCRIPTION
## 1. GPU Operator의 validation이 GPU workload와 충돌하는 이슈

노드 생성 직후 plugin validator가 GPU를 잡는데, 이 노드가 pending GPU workload에 의해 auto-scaling됐던 경우, 그 GPU workload가 동시에 GPU resource를 점유하려 시도하면서 실패하는 경우가 있습니다. (NVIDIA/gpu-operator#140, NVIDIA/gpu-operator#475)

이에 대응하기 위해 `WITH_WORKLOAD=false`라는 환경 변수를 넣어줄 수 있습니다.
이는 아래와 같은 Helm values로 설정 가능합니다.

```yaml
validator:
  plugin:
    env:
      - name: "WITH_WORKLOAD"
      - value: "false"
```

(장기적으로는 GPU operator 측 업데이트를 통해 노드가 validation이 끝나기 전에 pod을 받지 않게 해야 합니다.)

## 2. Helm values에 특정 literal을 사용할 수 없는 문제

1을 하고자 할 때 `false`라는 string literal을 넣어줄 수 없는 Helm의 구조적 문제(helm/helm#2848)가 있습니다.
Helm provider v2.0부터는 set에 type을 넣어 타입을 강제할 수 있습니다.

```
set {
    name  = "some_name"
    value = "some_value"
    type  = "string" # "auto" or "string"
}
```

기존 코드와의 호환성을 고려, `helm_values`에 더불어 `helm_values_force_string` 필드를 추가하고, 1의 변경이 이를 이용하도록 example을 수정합니다.

새 버전 0.1.4를 미리 사용합니다.