### PR TITLE
Change NVIDIA GPU Operator namespace options

### DIFF
--- a/modules/kubernetes-addons/nvidia-gpu-operator/main.tf
+++ b/modules/kubernetes-addons/nvidia-gpu-operator/main.tf
@@ -1,20 +1,11 @@
-resource "kubernetes_namespace_v1" "nvidia_gpu_operator" {
-  metadata {
-    name = var.k8s_namespace
-  }
-
-  timeouts {
-    delete = "15m"
-  }
-}
-
 resource "helm_release" "nvidia_gpu_operator" {
   repository = var.helm_repo_url
   chart      = var.helm_chart_name
 
-  namespace = var.k8s_namespace
-  name      = var.helm_release_name
-  version   = var.helm_chart_version
+  namespace        = var.k8s_namespace
+  name             = var.helm_release_name
+  version          = var.helm_chart_version
+  create_namespace = var.k8s_create_namespace
 
   set {
     name  = "serviceAccount.create"
@@ -47,8 +38,4 @@ resource "helm_release" "nvidia_gpu_operator" {
       type  = "string"
     }
   }
-
-  depends_on = [
-    kubernetes_namespace_v1.nvidia_gpu_operator
-  ]
 }

--- a/modules/kubernetes-addons/nvidia-gpu-operator/variables.tf
+++ b/modules/kubernetes-addons/nvidia-gpu-operator/variables.tf
@@ -42,12 +42,12 @@ variable "helm_release_name" {
 variable "k8s_create_namespace" {
   type        = bool
   default     = true
-  description = "Whether to create k8s namespace with name defined by `k8s_namespace`"
+  description = "Whether to create a k8s namespace with name defined by `k8s_namespace` if such namespace does not exist"
 }
 
 variable "k8s_namespace" {
   type        = string
-  default     = "nvidia-gpu-operator"
+  default     = "vessl"
   description = "The k8s namespace in which the nvidia-gpu-operator service account has been created"
 }
 


### PR DESCRIPTION
# 주요 수정내용
* GPU Operator addon의 `k8s_create_namespace`를 Helm에게 넘겨줍니다.
* GPU Operator addon의 default namespace를 `vessl`로 바꿉니다.

# 설명
Helm의 `create_namespace` 변수는 "namespace가 없으면 만들까?"를 나타냅니다.
GPU operator addon이 받는 `k8s_create_namespace` 변수를 여기로 넣어주면, 별도로 `kubernetes_namespace_v1` resource를 정의할 필요가 없습니다.

그리고, 설치하려는 클러스터의 상황(기존 GPU operator 존재 여부 등)에 따라 크게 달라지겠지만 우선은 default namespace를 vessl로 통일해 줍니다.