### PR TITLE
Add instance_market_options for spot instance.

### DIFF
--- a/modules/aws-eks-self-managed-node-group/main.tf
+++ b/modules/aws-eks-self-managed-node-group/main.tf
@@ -35,9 +35,10 @@ module "node_group" {
   // Without it, the security groups of the nodes are empty and thus won't join the cluster.
   vpc_security_group_ids = var.security_group_ids
 
-  min_size     = var.min_size
-  max_size     = var.max_size
-  desired_size = var.desired_size
+  min_size                = var.min_size
+  max_size                = var.max_size
+  desired_size            = var.desired_size
+  instance_market_options = var.instance_market_options
 
   # Pre-propagate necessary k8s node labels to autoscaling group tags in order to implement scale-to-zero
   # https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-can-i-scale-a-node-group-to-0

--- a/modules/aws-eks-self-managed-node-group/variables.tf
+++ b/modules/aws-eks-self-managed-node-group/variables.tf
@@ -91,6 +91,12 @@ variable "desired_size" {
   default     = 0
 }
 
+variable "instance_market_options" {
+  type        = map(any)
+  description = "The market (purchasing) option for the instances"
+  default     = {}
+}
+
 variable "tags" {
   type        = map(string)
   description = "The tags to apply to the node group"


### PR DESCRIPTION
노드 그룹의 스팟 인스턴스 대응을 위해, variables에 instance_market_option을 추가합니다.

참고자료
https://github.com/vessl-ai/terraform-aws-vessl-managed-cluster-suite/blob/71cad825352ea4a46303f995c4b6e13231952b30/node_groups.tf#L38C13-L38C36

션에게 감사!